### PR TITLE
feature: Do not format the files listed in .prettierignore

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -39,6 +39,14 @@ function runFormatting(
   return of(...files.files).pipe(
     mergeMap(async (file) => {
       const contents = await readFileAsync(file.path, 'utf-8');
+      const { ignored } = await prettier.getFileInfo(file.path, {
+        ignorePath: './.prettierignore',
+      });
+
+      if (ignored) {
+        return output;
+      }
+
       const formatted = prettier.format(contents, {
         ...(await prettier.resolveConfig(file.path)),
         filepath: file.path,


### PR DESCRIPTION
Now format the files listed in .prettierignore.
See .prettierignore and do not format the listed files.