### PR TITLE
Do not match directories, only files

### DIFF
--- a/src/master.ts
+++ b/src/master.ts
@@ -17,7 +17,7 @@ const bufferSize = 50;
 
 function runGlobs(files: string[], ignore: Ignore) {
   return new Observable<string>((subscriber) => {
-    const stream = globStream(files);
+    const stream = globStream(files, { nodir: true });
     stream.addListener('data', (data) => {
       if (!ignore.ignores(relative(data.cwd, data.path))) {
         subscriber.next(data);


### PR DESCRIPTION
glob-stream passes unknown options to https://github.com/isaacs/node-glob which accepts the nodir argument.

use case - we have a A.B.C/ directory and we prefer to run prettier on all files `*.*` and use prettier ignore to ignore unknown file extensions.