### PR TITLE
Include dot files in the pattern matching

### DIFF
--- a/src/master.ts
+++ b/src/master.ts
@@ -17,7 +17,7 @@ const bufferSize = 50;
 
 function runGlobs(files: string[], ignore: Ignore) {
   return new Observable<string>((subscriber) => {
-    const stream = globStream(files, { nodir: true });
+    const stream = globStream(files, { nodir: true, dot: true });
     stream.addListener('data', (data) => {
       if (!ignore.ignores(relative(data.cwd, data.path))) {
         subscriber.next(data);


### PR DESCRIPTION
The vanilla prettier matches dot files, while pprettier does not. This diverges from Prettier's behavior and will exclude files such as `.eslintrc.js` when using wildcard pattern like `**/*.js`.

This PR adds `dot: true` option to `globStream` so the pattern matching behavior stays consistent with prettier, making `pprettier` closer to be a drop-in replacement.